### PR TITLE
Add whitenoise to requirements.txt

### DIFF
--- a/sample/ellar-and-django-orm/requirements.txt
+++ b/sample/ellar-and-django-orm/requirements.txt
@@ -1,3 +1,4 @@
 Django
 ellar-cli
 ellar-django-module
+whitenoise


### PR DESCRIPTION
This is about the included sample app. I had to add whitenoise to requirements file otherwise running `manage.py` resulted in the following error:

```bash
  ...
  File "/home/paolo/devel/.venv/lib/python3.10/site-packages/ellar/app/factory.py", line 84, in _build_modules
    app_module = app_module.get_module("AppFactory")
  File "/home/paolo/devel/.venv/lib/python3.10/site-packages/ellar/core/modules/config.py", line 193, in get_module
    raise ImproperConfiguration(
ellar.common.exceptions.api.exceptions_types.ImproperConfiguration: Unable to import "ellar_and_django_orm.root_module:ApplicationModule" registered in "AppFactory"
```

The root cause of the issue is another exception, which was not displayed in the console:


```bash
  File "/home/paolo/devel/.venv/lib/python3.10/site-packages/django/utils/module_loading.py", line 15, in cached_import
    module = import_module(module_path)
  File "/home/paolo/.pyenv/versions/3.10.4/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'whitenoise'
```