### PR TITLE
Improve Django commands integration and --help fix

### DIFF
--- a/ellar_django/commands.py
+++ b/ellar_django/commands.py
@@ -19,7 +19,8 @@ class _CommandItem(t.NamedTuple):
 def get_command_description(command_name: str) -> str:
     module = get_commands()[command_name]
     CommandClass = load_command_class(module, command_name)
-    return CommandClass.help or ""
+    CommandClass.help = f"[{module.split('.')[0]}] {CommandClass.help}"
+    return CommandClass.help
 
 
 def generate_command_list() -> t.List[_CommandItem]:
@@ -36,15 +37,20 @@ def generate_command_list() -> t.List[_CommandItem]:
 _django_support_commands = generate_command_list()
 
 
-def version_callback(ctx: click.Context, _: t.Any, value: bool) -> None:
+def version_callback(ctx: click.Context, _: click.Parameter, value: bool) -> None:
     if value:
         click.echo(f"Django Version: {django.__version__}")
         ctx.exit()
 
 
+def show_help_callback(ctx: click.Context, _: click.Parameter, value: bool) -> None:
+    command_args = ["manage.py", ctx.info_name, "--help"]
+    django.core.management.execute_from_command_line(command_args)
+
+
 @click.group(
     name="django",
-    help="- Ellar Django Commands",
+    help="Ellar Django Commands",
 )
 @click.option(
     "-v",
@@ -70,6 +76,7 @@ def _add_django_command(command_item: _CommandItem) -> None:
     @click.option(
         "-h",
         "--help",
+        callback=show_help_callback,
         help="Show the command help.",
         is_flag=True,
         expose_value=False,


### PR DESCRIPTION
@eadwinCode hi again,

I've managed to add  `django_extensions` to `INSTALLED_APPS` and noticed that the commands weren't recognized. Specifically, I was interested in running `python manage.py django shell_plus`, provided by django_extensions, but couldn't execute the command. So, I attempted to adjust the `commands.py` file as you can see in the commit.

Now, the output appears as follows:

```bash
❯ python manage.py django 
Usage: Ellar Web Framework CLI django [OPTIONS] COMMAND [ARGS]...

  Ellar Django Commands

Options:
  -v, --version  Show the version and exit.
  --help         Show this message and exit.

Commands:
  admin_generator             [django_extensions] Generate a `admin.py`...
  changepassword              [django] Change a user's password for...
  check                       [django] Checks the entire Django project...
  clean_pyc                   [django_extensions] Removes all python...
  clear_cache                 [django_extensions] Fully clear site-wide...
  clearsessions               [django] Can be run as a cronjob or...
  collectstatic               [django] Collect static files in a single...
  compile_pyc                 [django_extensions] Compile python bytecode...
  compilemessages             [django] Compiles .po files to .mo files...
  create_command              [django_extensions] Creates a Django...
  create_jobs                 [django_extensions] Creates a Django jobs...
  create_template_tags        [django_extensions] Creates a Django...
  createcachetable            [django] Creates the tables needed to use...
  createsuperuser             [django] Used to create a superuser.
  dbshell                     [django] Runs the command-line client for...
  delete_squashed_migrations  [django_extensions] Deletes left over...
  describe_form               [django_extensions] Outputs the specified...
  diffsettings                [django] Displays differences between the...
  drop_test_database          [django_extensions] Drops test database for...
  dumpdata                    [django] Output the contents of the...
  dumpscript                  [django_extensions] Dumps the data as a...
  export_emails               [django_extensions] Export user email...
  find_template               [django_extensions] Finds the location of...
  findstatic                  [django] Finds the absolute paths for the...
  flush                       [django] Removes ALL DATA from the...
  generate_password           [django_extensions] Generates a new...
  generate_secret_key         [django_extensions] Generates a new...
  graph_models                [django_extensions] Creates a GraphViz dot...
  inspectdb                   [django] Introspects the database tables in...
  list_model_info             [django_extensions] List out the fields and...
  list_signals                [django_extensions] List all signals by...
  loaddata                    [django] Installs the named fixture(s) in...
  mail_debug                  [django_extensions] Starts a test mail...
  makemessages                [django] Runs over the entire source tree...
  makemigrations              [django] Creates new migration(s) for apps.
  managestate                 [django_extensions] Manage database state...
  merge_model_instances       [django_extensions] Removes duplicate model...
  migrate                     [django] Updates database schema.
  myrunserver                 [apps] Avvia il server Uvicorn con...
  notes                       [django_extensions] Show all annotations...
  optimizemigration           [django] Optimizes the operations for the...
  pipchecker                  [django_extensions] Scan pip requirement...
  print_settings              [django_extensions] Print the active Django...
  print_user_for_session      [django_extensions] print the user...
  raise_test_exception        [django_extensions] Raises a test Exception...
  remove_stale_contenttypes   [django] Deletes stale content types in the...
  reset_db                    [django_extensions] Resets the database for...
  reset_schema                [django_extensions] Recreates the public...
  runjob                      [django_extensions] Run a single...
  runjobs                     [django_extensions] Runs scheduled...
  runprofileserver            [django_extensions] Starts a lightweight...
  runscript                   [django_extensions] Runs a script in django...
  runserver_plus              [django_extensions] Starts a lightweight...
  sendtestemail               [django] Sends a test email to the email...
  set_default_site            [django_extensions] Set parameters of the...
  set_fake_emails             [django_extensions] DEBUG only: give all...
  set_fake_passwords          [django_extensions] DEBUG only: sets all...
  shell                       [django] Runs a Python interactive...
  shell_plus                  [django_extensions] Like the 'shell'...
  show_template_tags          [django_extensions] Displays template tags...
  show_urls                   [django_extensions] Displays all of the url...
  showmigrations              [django] Shows all available migrations for...
  sqlcreate                   [django_extensions] Generates the SQL to...
  sqldiff                     [django_extensions] Prints the...
  sqldsn                      [django_extensions] Prints DSN on stdout,...
  sqlflush                    [django] Returns a list of the SQL...
  sqlmigrate                  [django] Prints the SQL statements for the...
  sqlsequencereset            [django] Prints the SQL statements for...
  squashmigrations            [django] Squashes an existing set of...
  sync_s3                     [django_extensions] Syncs the complete...
  syncdata                    [django_extensions] Makes the current...
  test                        [django] Discover and run tests in the...
  testserver                  [django] Runs a development server with...
  unreferenced_files          [django_extensions] Prints a list of all...
  update_permissions          [django_extensions] reloads permissions for...
  validate_templates          [django_extensions] Validate templates on...
```

Additionally, I noticed that `--help` was only partially functional, showing only the short description without further details. Now, the output looks like:

```bash
❯ python manage.py django shell --help
usage: manage.py shell [-h] [--no-startup] [-i {ipython,bpython,python}] [-c COMMAND] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback]
                       [--no-color] [--force-color]

Runs a Python interactive interpreter. Tries to use IPython or bpython, if one of them is available. Any standard input is executed as code.

options:
  -h, --help            show this help message and exit
  --no-startup          When using plain Python, ignore the PYTHONSTARTUP environment variable and ~/.pythonrc.py script.
  -i {ipython,bpython,python}, --interface {ipython,bpython,python}
                        Specify an interactive interpreter interface. Available options: "ipython", "bpython", and "python"
  -c COMMAND, --command COMMAND
                        Instead of opening an interactive shell, run a command as Django and exit.
  --version             Show program's version number and exit.
  -v {0,1,2,3}, --verbosity {0,1,2,3}
                        Verbosity level; 0=minimal output, 1=normal output, 2=verbose output, 3=very verbose output
  --settings SETTINGS   The Python path to a settings module, e.g. "myproject.settings.main". If this isn't provided, the DJANGO_SETTINGS_MODULE environment variable will be used.
  --pythonpath PYTHONPATH
                        A directory to add to the Python path, e.g. "/home/djangoprojects/myproject".
  --traceback           Raise on CommandError exceptions.
  --no-color            Don't colorize the command output.
  --force-color         Force colorization of the command output.
```

However, I still lack confidence in how Django's command machinery works, and tests are mostly absent, making it feel fragile. Furthermore, I'm not satisfied with how we manage the command blacklist. For instance, to blacklist certain commands (e.g., runserver_plus from django_extensions), we have to modify the hardcoded values of `BLACKLISTED_COMMANDS` in the source... which seems functional but unsatisfactory.

I noticed in an earlier version that you attempted to use Typer and then removed it. I tried to integrate [django-typer](https://github.com/bckohan/django-typer) without success, mainly due to my lack of understanding.

Lastly, I'd like to hear your thoughts on this and whether we should enhance this management or if you find it sufficient as it stands. And ideally, without causing any unintended side effects.